### PR TITLE
fix: email sender not valid

### DIFF
--- a/src/app/(public)/guides/components.tsx
+++ b/src/app/(public)/guides/components.tsx
@@ -1,0 +1,14 @@
+import { Container, TextInput } from "octagon-ui";
+
+export const GuideList = () => {
+	return (
+		<div>
+			<Container align="center">
+				<TextInput label="buscar" placeholder="ingresa un nombre" />
+			</Container>
+			<Container>
+				<p>Guias</p>
+			</Container>
+		</div>
+	);
+};

--- a/src/app/(public)/guides/page.tsx
+++ b/src/app/(public)/guides/page.tsx
@@ -1,14 +1,12 @@
 import { Metadata } from "next";
 
+import { GuideList } from "./components";
+
 export const metadata: Metadata = {
 	title: "PNFi | Guias",
 	description: "Programa Nacional de Formacion en Informatica"
 };
 
 export default function PageGuides() {
-	return (
-		<ul>
-			<li>Guia</li>
-		</ul>
-	);
+	return <GuideList />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default async function HomePage() {
 
 	return (
 		<>
-			<Nav session={Boolean(session)} />
+			<Nav session={Boolean(session?.user?.id)} />
 			<main>
 				<Home week={week} schedule={schedules[0]?.id} />
 			</main>

--- a/src/contexts/system/email/domain/ArchivedEmail.ts
+++ b/src/contexts/system/email/domain/ArchivedEmail.ts
@@ -17,7 +17,7 @@ export type ArchivedEmailPrimitives = {
 };
 
 export class ArchivedEmail extends Email {
-	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <no-reply@pnfi.pro>";
+	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <octagon@pnfi.pro>";
 
 	private constructor(
 		id: EmailId,

--- a/src/contexts/system/email/domain/BlockedEmail.ts
+++ b/src/contexts/system/email/domain/BlockedEmail.ts
@@ -17,7 +17,7 @@ export type BlockedEmailPrimitives = {
 };
 
 export class BlockedEmail extends Email {
-	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <no-reply@pnfi.pro>";
+	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <octagon@pnfi.pro>";
 
 	private constructor(
 		id: EmailId,

--- a/src/contexts/system/email/domain/RestoredEmail.ts
+++ b/src/contexts/system/email/domain/RestoredEmail.ts
@@ -17,7 +17,7 @@ export type BlockedEmailPrimitives = {
 };
 
 export class RestoredEmail extends Email {
-	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "noreply@octaogn.uptag.net";
+	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "octagon@pnfi.pro";
 
 	private constructor(
 		id: EmailId,

--- a/src/contexts/system/email/domain/UserUpdatedNotificationEmail.ts
+++ b/src/contexts/system/email/domain/UserUpdatedNotificationEmail.ts
@@ -18,7 +18,7 @@ export type UserUpdatedNotificationEmailPrimitives = {
 };
 
 export class UserUpdatedNotificationEmail extends Email {
-	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <no-reply@pnfi.pro>";
+	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <octagon@pnfi.pro>";
 
 	private constructor(
 		id: EmailId,

--- a/src/contexts/system/email/domain/WelcomeEmail.ts
+++ b/src/contexts/system/email/domain/WelcomeEmail.ts
@@ -17,7 +17,8 @@ export type WelcomeEmailPrimitives = {
 };
 
 export class WelcomeEmail extends Email {
-	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <no-reply@pnfi.pro>";
+	private static readonly from = process.env.SYSTEM_EMAIL_SENDER ?? "PNFi <octagon@pnfi.pro>";
+	private static readonly confirmationUrl = process.env.CONFIRMATION_URL ?? "https://pnfi.pro/";
 
 	private constructor(
 		id: EmailId,
@@ -79,7 +80,7 @@ export class WelcomeEmail extends Email {
 
 	private static generateBody(id: string, userName: string): EmailBody {
 		return new EmailBody(
-			`Bienvenido a la cartelera del PNFi, ${userName}! Completa tu registro utilizando el enlace de invitacion:\nhttps://octagon.uptag.net/confirm?id=${id}`
+			`Bienvenido a la cartelera del PNFi, ${userName} 🎉\nAntes de proseguir, debes confirmar tu correo electrónico iniciando sesión en:\n${this.confirmationUrl}`
 		);
 	}
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,10 +12,11 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 	providers: [
 		...authConfig.providers,
 		Google({
-			[customFetch]: fetch
+			[customFetch]: fetch,
+			allowDangerousEmailAccountLinking: true
 		}),
 		Resend({
-			from: "PNFi <no-reply@pnfi.pro>"
+			from: "PNFi <octagon@pnfi.pro>"
 		})
 	],
 	session: { strategy: "jwt" },


### PR DESCRIPTION
This pull request includes several changes to improve the user interface and update email sender addresses. The most important changes include the addition of a new `GuideList` component, the update of email sender addresses, and a minor adjustment in the `Nav` component.

### User Interface Improvements:
* [`src/app/(public)/guides/components.tsx`](diffhunk://#diff-9f6e0457b8acf2c0ae7a54b862049c15e569a47a5ac8fb7879b810552a7ce1caR1-R14): Added a new `GuideList` component that includes a `TextInput` for searching and a container for displaying guides.
* [`src/app/(public)/guides/page.tsx`](diffhunk://#diff-8a599db387eb7eb44554f1826bbafcfcc4b32dc03fe6619311ce49773517f6d9R3-R11): Updated the `PageGuides` component to use the new `GuideList` component.

### Email Sender Address Updates:
* [`src/contexts/system/email/domain/ArchivedEmail.ts`](diffhunk://#diff-633ac99ad74ff4a7c6e6599054971e849cbf94fe20223a0a0583a217a0c7d941L20-R20): Updated the default email sender address to "PNFi <octagon@pnfi.pro>".
* [`src/contexts/system/email/domain/BlockedEmail.ts`](diffhunk://#diff-cc73815a766338ba12e91fa91328a5da4d9e91ca777663e05a9ebc65b83d8e92L20-R20): Updated the default email sender address to "PNFi <octagon@pnfi.pro>".
* [`src/contexts/system/email/domain/RestoredEmail.ts`](diffhunk://#diff-43e93208c58c66094e2981ad0e5e374451000f6aa58ed0a0c739e9ff61584e34L20-R20): Updated the default email sender address to "octagon@pnfi.pro".
* [`src/contexts/system/email/domain/UserUpdatedNotificationEmail.ts`](diffhunk://#diff-52039a58eef0769893de247d84c56cc67684907d7ac1665c56a37c8f1a320119L21-R21): Updated the default email sender address to "PNFi <octagon@pnfi.pro>".
* [`src/contexts/system/email/domain/WelcomeEmail.ts`](diffhunk://#diff-1e55557e31af56ab8f9ca3a01b511e205394453ae73a092a00bc1cbb9fcd5236L20-R21): Updated the default email sender address to "PNFi <octagon@pnfi.pro>" and added a confirmation URL. [[1]](diffhunk://#diff-1e55557e31af56ab8f9ca3a01b511e205394453ae73a092a00bc1cbb9fcd5236L20-R21) [[2]](diffhunk://#diff-1e55557e31af56ab8f9ca3a01b511e205394453ae73a092a00bc1cbb9fcd5236L82-R83)

### Minor Adjustments:
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL26-R26): Modified the `Nav` component to check for the presence of `session?.user?.id` instead of just `session`.
* [`src/lib/auth.ts`](diffhunk://#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78L15-R19): Enabled dangerous email account linking for Google provider and updated the default email sender address for the Resend provider.