### PR TITLE
feat: add missing application tests for cma context

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-npx --no -- commitlint --edit $1

--- a/tests/contexts/cma/announcements/application/archive/AnnouncementArchiver.test.ts
+++ b/tests/contexts/cma/announcements/application/archive/AnnouncementArchiver.test.ts
@@ -1,0 +1,33 @@
+import { AnnouncementArchiver } from "../../../../../../src/contexts/cma/announcements/application/archive/AnnouncementArchiver";
+import { AnnouncementIsArchivedError } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementIsArchivedError";
+import { AnnouncementStatus } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementArchivedDomainEventMother } from "../../domain/event/AnnouncementArchivedDomainEventMother";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementArchiver should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const archiver = new AnnouncementArchiver(repository, eventBus);
+
+	it("archive a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.DRAFT);
+		const expectedDomainEvent = AnnouncementArchivedDomainEventMother.create(expectedAnnouncement);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldSave();
+		eventBus.shouldPublish([expectedDomainEvent]);
+
+		await archiver.archive(expectedAnnouncement.toPrimitives().id);
+
+		const savedAnnouncement = repository.getSavedAnnouncement();
+		expect(savedAnnouncement?.isArchived()).toBe(true);
+	});
+
+	it("throw an error when announcement is already archived", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.ARCHIVED);
+		repository.shouldSearch(expectedAnnouncement);
+
+		await expect(archiver.archive(expectedAnnouncement.toPrimitives().id)).rejects.toThrow(AnnouncementIsArchivedError);
+	});
+});

--- a/tests/contexts/cma/announcements/application/find/AnnouncementFinder.test.ts
+++ b/tests/contexts/cma/announcements/application/find/AnnouncementFinder.test.ts
@@ -1,0 +1,31 @@
+import { faker } from "@faker-js/faker";
+import { AnnouncementFinder } from "../../../../../../src/contexts/cma/announcements/application/find/AnnouncementFinder";
+import { AnnouncementDoesNotExistError } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementDoesNotExistError";
+import { AnnouncementId } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementId";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementFinder should", () => {
+	const repository = new MockAnnouncementRepository();
+	const finder = new AnnouncementFinder(repository);
+
+	it("find a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create();
+		const expectedAnnouncementPrimitives = expectedAnnouncement.toPrimitives();
+		repository.shouldSearch(expectedAnnouncement);
+
+		const announcement = await finder.find(expectedAnnouncementPrimitives.id);
+
+		repository.assertSearchHaveBeenCalledWith(new AnnouncementId(expectedAnnouncementPrimitives.id));
+		expect(announcement).toEqual(expectedAnnouncementPrimitives);
+	});
+
+	it("throw an error when announcement does not exist", async () => {
+		const id = faker.string.uuid();
+		repository.shouldSearch(null);
+
+		await expect(finder.find(id)).rejects.toThrow(AnnouncementDoesNotExistError);
+
+		repository.assertSearchHaveBeenCalledWith(new AnnouncementId(id));
+	});
+});

--- a/tests/contexts/cma/announcements/application/post/AnnouncementPoster.test.ts
+++ b/tests/contexts/cma/announcements/application/post/AnnouncementPoster.test.ts
@@ -1,0 +1,26 @@
+import { AnnouncementPoster } from "../../../../../../src/contexts/cma/announcements/application/post/AnnouncementPoster";
+import { AnnouncementPostedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementPostedDomainEvent";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementPoster should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const poster = new AnnouncementPoster(repository, eventBus);
+
+	it("post a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create();
+		const expectedAnnouncementPrimitives = expectedAnnouncement.toPrimitives();
+		repository.shouldSave();
+
+		await poster.post(
+			expectedAnnouncementPrimitives.id,
+			expectedAnnouncementPrimitives.title,
+			expectedAnnouncementPrimitives.type,
+			expectedAnnouncementPrimitives.content
+		);
+
+		eventBus.assertLastPublishedEventIs(AnnouncementPostedDomainEvent);
+	});
+});

--- a/tests/contexts/cma/announcements/application/publish/AnnouncementPublisher.test.ts
+++ b/tests/contexts/cma/announcements/application/publish/AnnouncementPublisher.test.ts
@@ -1,0 +1,25 @@
+import { AnnouncementPublisher } from "../../../../../../src/contexts/cma/announcements/application/publish/AnnouncementPublisher";
+import { AnnouncementStatus } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementPublishedDomainEventMother } from "../../domain/event/AnnouncementPublishedDomainEventMother";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementPublisher should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const publisher = new AnnouncementPublisher(repository, eventBus);
+
+	it("publish a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.DRAFT);
+		const expectedDomainEvent = AnnouncementPublishedDomainEventMother.create(expectedAnnouncement);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldSave();
+		eventBus.shouldPublish([expectedDomainEvent]);
+
+		await publisher.publish(expectedAnnouncement.toPrimitives().id);
+
+		const savedAnnouncement = repository.getSavedAnnouncement();
+		expect(savedAnnouncement?.isPublished()).toBe(true);
+	});
+});

--- a/tests/contexts/cma/announcements/application/remove/AnnouncementRemover.test.ts
+++ b/tests/contexts/cma/announcements/application/remove/AnnouncementRemover.test.ts
@@ -1,0 +1,23 @@
+import { AnnouncementRemover } from "../../../../../../src/contexts/cma/announcements/application/remove/AnnouncementRemover";
+import { AnnouncementRemovedDomainEventMother } from "../../domain/event/AnnouncementRemovedDomainEventMother";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementRemover should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const remover = new AnnouncementRemover(repository, eventBus);
+
+	it("remove a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create();
+		const expectedDomainEvent = AnnouncementRemovedDomainEventMother.create(expectedAnnouncement);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldRemove();
+		eventBus.shouldPublish([expectedDomainEvent]);
+
+		await remover.remove(expectedAnnouncement.toPrimitives().id);
+
+		repository.assertRemoveHaveBeenCalledWith(expectedAnnouncement);
+	});
+});

--- a/tests/contexts/cma/announcements/application/restore/AnnouncementRestorer.test.ts
+++ b/tests/contexts/cma/announcements/application/restore/AnnouncementRestorer.test.ts
@@ -1,0 +1,33 @@
+import { AnnouncementRestorer } from "../../../../../../src/contexts/cma/announcements/application/restore/AnnouncementRestorer";
+import { AnnouncementIsNotArchivedError } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementIsNotArchivedError";
+import { AnnouncementStatus } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementRestoredDomainEventMother } from "../../domain/event/AnnouncementRestoredDomainEventMother";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementRestorer should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const restorer = new AnnouncementRestorer(repository, eventBus);
+
+	it("restore a valid announcement", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.ARCHIVED);
+		const expectedDomainEvent = AnnouncementRestoredDomainEventMother.create(expectedAnnouncement);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldSave();
+		eventBus.shouldPublish([expectedDomainEvent]);
+
+		await restorer.restore(expectedAnnouncement.toPrimitives().id);
+
+		const savedAnnouncement = repository.getSavedAnnouncement();
+		expect(savedAnnouncement?.isDraft()).toBe(true);
+	});
+
+	it("throw an error when announcement is not archived", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.DRAFT);
+		repository.shouldSearch(expectedAnnouncement);
+
+		await expect(restorer.restore(expectedAnnouncement.toPrimitives().id)).rejects.toThrow(AnnouncementIsNotArchivedError);
+	});
+});

--- a/tests/contexts/cma/announcements/application/search-by-criteria/AnnouncementsByCriteriaSearcher.test.ts
+++ b/tests/contexts/cma/announcements/application/search-by-criteria/AnnouncementsByCriteriaSearcher.test.ts
@@ -1,0 +1,21 @@
+import { AnnouncementsByCriteriaSearcher } from "../../../../../../src/contexts/cma/announcements/application/search-by-criteria/AnnouncementsByCriteriaSearcher";
+import { Criteria } from "../../../../../../src/contexts/shared/domain/criteria/Criteria";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+
+describe("AnnouncementsByCriteriaSearcher should", () => {
+	const repository = new MockAnnouncementRepository();
+	const searcher = new AnnouncementsByCriteriaSearcher(repository);
+
+	it("search announcements by criteria", async () => {
+		const expectedAnnouncements = [AnnouncementMother.create(), AnnouncementMother.create()];
+		const expectedAnnouncementsPrimitives = expectedAnnouncements.map(a => a.toPrimitives());
+		const criteria = Criteria.fromPrimitives([], null, null, null, null);
+		repository.shouldMatch(expectedAnnouncements);
+
+		const announcements = await searcher.search([], null, null, null, null);
+
+		repository.assertMatchingHaveBeenCalledWith(criteria);
+		expect(announcements).toEqual(expectedAnnouncementsPrimitives);
+	});
+});

--- a/tests/contexts/cma/announcements/application/update-content/AnnouncementContentUpdater.test.ts
+++ b/tests/contexts/cma/announcements/application/update-content/AnnouncementContentUpdater.test.ts
@@ -1,0 +1,35 @@
+import { AnnouncementContentUpdater } from "../../../../../../src/contexts/cma/announcements/application/update-content/AnnouncementContentUpdater";
+import { AnnouncementIsArchivedError } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementIsArchivedError";
+import { AnnouncementStatus } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementContentUpdatedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementContentUpdatedDomainEvent";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+import { AnnouncementContentMother } from "../../domain/AnnouncementContentMother";
+
+describe("AnnouncementContentUpdater should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const updater = new AnnouncementContentUpdater(repository, eventBus);
+
+	it("update a valid announcement content", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.DRAFT);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldSave();
+		const newContent = AnnouncementContentMother.create();
+
+		await updater.update(expectedAnnouncement.toPrimitives().id, newContent.value);
+
+		const savedAnnouncement = repository.getSavedAnnouncement();
+		expect(savedAnnouncement?.toPrimitives().content).toBe(newContent.value);
+		eventBus.assertLastPublishedEventIs(AnnouncementContentUpdatedDomainEvent);
+	});
+
+	it("throw an error when announcement is archived", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.ARCHIVED);
+		repository.shouldSearch(expectedAnnouncement);
+		const newContent = AnnouncementContentMother.create();
+
+		await expect(updater.update(expectedAnnouncement.toPrimitives().id, newContent.value)).rejects.toThrow(AnnouncementIsArchivedError);
+	});
+});

--- a/tests/contexts/cma/announcements/application/update-title/AnnouncementTitleUpdater.test.ts
+++ b/tests/contexts/cma/announcements/application/update-title/AnnouncementTitleUpdater.test.ts
@@ -1,0 +1,35 @@
+import { AnnouncementTitleUpdater } from "../../../../../../src/contexts/cma/announcements/application/update-title/AnnouncementTitleUpdater";
+import { AnnouncementIsArchivedError } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementIsArchivedError";
+import { AnnouncementStatus } from "../../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementTitleUpdatedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementTitleUpdatedDomainEvent";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { AnnouncementMother } from "../../domain/AnnouncementMother";
+import { MockAnnouncementRepository } from "../../infrastructure/MockAnnouncementRepository";
+import { AnnouncementTitleMother } from "../../domain/AnnouncementTitleMother";
+
+describe("AnnouncementTitleUpdater should", () => {
+	const repository = new MockAnnouncementRepository();
+	const eventBus = new MockEventBus();
+	const updater = new AnnouncementTitleUpdater(repository, eventBus);
+
+	it("update a valid announcement title", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.DRAFT);
+		repository.shouldSearch(expectedAnnouncement);
+		repository.shouldSave();
+		const newTitle = AnnouncementTitleMother.create();
+
+		await updater.update(expectedAnnouncement.toPrimitives().id, newTitle.value);
+
+		const savedAnnouncement = repository.getSavedAnnouncement();
+		expect(savedAnnouncement?.toPrimitives().title).toBe(newTitle.value);
+		eventBus.assertLastPublishedEventIs(AnnouncementTitleUpdatedDomainEvent);
+	});
+
+	it("throw an error when announcement is archived", async () => {
+		const expectedAnnouncement = AnnouncementMother.create(undefined, undefined, undefined, undefined, undefined, AnnouncementStatus.ARCHIVED);
+		repository.shouldSearch(expectedAnnouncement);
+		const newTitle = AnnouncementTitleMother.create();
+
+		await expect(updater.update(expectedAnnouncement.toPrimitives().id, newTitle.value)).rejects.toThrow(AnnouncementIsArchivedError);
+	});
+});

--- a/tests/contexts/cma/announcements/domain/AnnouncementContentMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementContentMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementContent } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementContent";
+
+export class AnnouncementContentMother {
+	static create(value?: string): AnnouncementContent {
+		return new AnnouncementContent(value ?? faker.lorem.paragraph({ min: 1, max: 3 }));
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementIdMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementIdMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementId } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementId";
+
+export class AnnouncementIdMother {
+	static create(value?: string): AnnouncementId {
+		return new AnnouncementId(value ?? faker.string.uuid());
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementMother.ts
@@ -1,0 +1,33 @@
+import { Announcement } from "../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementContent } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementContent";
+import { AnnouncementId } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementId";
+import { AnnouncementPublishDate } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementPublishDate";
+import { AnnouncementStatus } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+import { AnnouncementTitle } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementTitle";
+import { AnnouncementType } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementType";
+import { AnnouncementContentMother } from "./AnnouncementContentMother";
+import { AnnouncementIdMother } from "./AnnouncementIdMother";
+import { AnnouncementPublishDateMother } from "./AnnouncementPublishDateMother";
+import { AnnouncementStatusMother } from "./AnnouncementStatusMother";
+import { AnnouncementTitleMother } from "./AnnouncementTitleMother";
+import { AnnouncementTypeMother } from "./AnnouncementTypeMother";
+
+export class AnnouncementMother {
+	static create(
+		id?: AnnouncementId,
+		title?: AnnouncementTitle,
+		content?: AnnouncementContent,
+		publishDate?: AnnouncementPublishDate,
+		type?: AnnouncementType,
+		status?: AnnouncementStatus
+	): Announcement {
+		return new Announcement(
+			id ?? AnnouncementIdMother.create(),
+			title ?? AnnouncementTitleMother.create(),
+			content ?? AnnouncementContentMother.create(),
+			publishDate ?? AnnouncementPublishDateMother.create(),
+			type ?? AnnouncementTypeMother.create(),
+			status ?? AnnouncementStatusMother.create()
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementPublishDateMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementPublishDateMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementPublishDate } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementPublishDate";
+
+export class AnnouncementPublishDateMother {
+	static create(value?: Date): AnnouncementPublishDate {
+		return new AnnouncementPublishDate(value ?? faker.date.recent());
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementStatusMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementStatusMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementStatus } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementStatus";
+
+export class AnnouncementStatusMother {
+	static create(value?: AnnouncementStatus): AnnouncementStatus {
+		return value ?? faker.helpers.enumValue(AnnouncementStatus);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementTitleMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementTitleMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementTitle } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementTitle";
+
+export class AnnouncementTitleMother {
+	static create(value?: string): AnnouncementTitle {
+		return new AnnouncementTitle(value ?? faker.lorem.sentence({ min: 5, max: 10 }));
+	}
+}

--- a/tests/contexts/cma/announcements/domain/AnnouncementTypeMother.ts
+++ b/tests/contexts/cma/announcements/domain/AnnouncementTypeMother.ts
@@ -1,0 +1,9 @@
+import { faker } from "@faker-js/faker";
+
+import { AnnouncementType } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementType";
+
+export class AnnouncementTypeMother {
+	static create(value?: AnnouncementType): AnnouncementType {
+		return value ?? faker.helpers.enumValue(AnnouncementType);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementArchivedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementArchivedDomainEventMother.ts
@@ -1,0 +1,13 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementArchivedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementArchivedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementArchivedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementArchivedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementArchivedDomainEvent(
+			anouncementPrimitives.id
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementContentUpdatedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementContentUpdatedDomainEventMother.ts
@@ -1,0 +1,14 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementContentUpdatedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementContentUpdatedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementContentUpdatedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementContentUpdatedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementContentUpdatedDomainEvent(
+			anouncementPrimitives.id,
+			anouncementPrimitives.content
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementPostedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementPostedDomainEventMother.ts
@@ -1,0 +1,17 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementPostedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementPostedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementPostedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementPostedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementPostedDomainEvent(
+			anouncementPrimitives.id,
+			anouncementPrimitives.title,
+			anouncementPrimitives.content,
+			anouncementPrimitives.publishDate,
+			anouncementPrimitives.type
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementPublishedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementPublishedDomainEventMother.ts
@@ -1,0 +1,17 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementPublishedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementPublishedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementPublishedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementPublishedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementPublishedDomainEvent(
+			anouncementPrimitives.id,
+			anouncementPrimitives.title,
+			anouncementPrimitives.content,
+			anouncementPrimitives.publishDate,
+			anouncementPrimitives.type
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementRemovedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementRemovedDomainEventMother.ts
@@ -1,0 +1,13 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementRemovedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementRemovedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementRemovedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementRemovedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementRemovedDomainEvent(
+			anouncementPrimitives.id
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementRestoredDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementRestoredDomainEventMother.ts
@@ -1,0 +1,13 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementRestoredDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementRestoredDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementRestoredDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementRestoredDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementRestoredDomainEvent(
+			anouncementPrimitives.id
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/domain/event/AnnouncementTitleUpdatedDomainEventMother.ts
+++ b/tests/contexts/cma/announcements/domain/event/AnnouncementTitleUpdatedDomainEventMother.ts
@@ -1,0 +1,14 @@
+import { Announcement } from "../../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementTitleUpdatedDomainEvent } from "../../../../../../src/contexts/cma/announcements/domain/event/AnnouncementTitleUpdatedDomainEvent";
+import { AnnouncementMother } from "../AnnouncementMother";
+
+export class AnnouncementTitleUpdatedDomainEventMother {
+	static create(announcement?: Announcement): AnnouncementTitleUpdatedDomainEvent {
+		const anouncementPrimitives = (announcement ?? AnnouncementMother.create()).toPrimitives();
+
+		return new AnnouncementTitleUpdatedDomainEvent(
+			anouncementPrimitives.id,
+			anouncementPrimitives.title
+		);
+	}
+}

--- a/tests/contexts/cma/announcements/infrastructure/MockAnnouncementRepository.ts
+++ b/tests/contexts/cma/announcements/infrastructure/MockAnnouncementRepository.ts
@@ -1,0 +1,78 @@
+import { Announcement } from "../../../../../src/contexts/cma/announcements/domain/Announcement";
+import { AnnouncementId } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementId";
+import { AnnouncementRepository } from "../../../../../src/contexts/cma/announcements/domain/AnnouncementRepository";
+import { Criteria } from "../../../../../src/contexts/shared/domain/criteria/Criteria";
+
+export class MockAnnouncementRepository implements AnnouncementRepository {
+	private readonly mockSave = jest.fn();
+	private savedAnnouncement: Announcement | null = null;
+	private readonly mockSearch = jest.fn();
+	private readonly mockSearchAll = jest.fn();
+	private readonly mockMatching = jest.fn();
+	private readonly mockRemove = jest.fn();
+
+	async save(announcement: Announcement): Promise<void> {
+		this.mockSave(announcement);
+		this.savedAnnouncement = announcement;
+	}
+
+	async search(id: AnnouncementId): Promise<Announcement | null> {
+		return this.mockSearch(id);
+	}
+
+	async searchAll(): Promise<Announcement[]> {
+		return this.mockSearchAll();
+	}
+
+	async matching(criteria: Criteria): Promise<Announcement[]> {
+		return this.mockMatching(criteria);
+	}
+
+	async remove(announcement: Announcement): Promise<void> {
+		this.mockRemove(announcement);
+	}
+
+	shouldSave(): void {
+		this.mockSave.mockReturnValue(Promise.resolve());
+	}
+
+	shouldSearch(announcement: Announcement | null): void {
+		this.mockSearch.mockReturnValue(Promise.resolve(announcement));
+	}
+
+	shouldSearchAll(announcements: Announcement[]): void {
+		this.mockSearchAll.mockReturnValue(Promise.resolve(announcements));
+	}
+
+	shouldMatch(announcements: Announcement[]): void {
+		this.mockMatching.mockReturnValue(Promise.resolve(announcements));
+	}
+
+	shouldRemove(): void {
+		this.mockRemove.mockReturnValue(Promise.resolve());
+	}
+
+	assertSaveHaveBeenCalledWith(announcement: Announcement): void {
+		expect(this.mockSave).toHaveBeenCalledWith(announcement);
+	}
+
+	assertSearchHaveBeenCalledWith(id: AnnouncementId): void {
+		expect(this.mockSearch).toHaveBeenCalledWith(id);
+	}
+
+	assertSearchAllHaveBeenCalled(): void {
+		expect(this.mockSearchAll).toHaveBeenCalled();
+	}
+
+	assertMatchingHaveBeenCalledWith(criteria: Criteria): void {
+		expect(this.mockMatching).toHaveBeenCalledWith(criteria);
+	}
+
+	assertRemoveHaveBeenCalledWith(announcement: Announcement): void {
+		expect(this.mockRemove).toHaveBeenCalledWith(announcement);
+	}
+
+	getSavedAnnouncement(): Announcement | null {
+		return this.savedAnnouncement;
+	}
+}

--- a/tests/contexts/cma/users/application/registrar/UserRegistrar.test.ts
+++ b/tests/contexts/cma/users/application/registrar/UserRegistrar.test.ts
@@ -1,6 +1,7 @@
 import { UserRegistrar } from "../../../../../../src/contexts/cma/users/application/registrar/UserRegistrar";
-import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
+import { UserRegisteredDomainEvent } from "../../../../../../src/contexts/cma/users/domain/event/UserRegisteredDomainEvent";
 import { UserRegisteredDomainEventMother } from "../../domain/event/UserRegisteredDomainEventMother";
+import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
 import { UserMother } from "../../domain/UserMother";
 import { MockUserRepository } from "../../infrastructure/MockUserRepository";
 
@@ -12,10 +13,7 @@ describe("UserRegistrar should", () => {
 	it("register a valid user", async () => {
 		const expectedUser = UserMother.create();
 		const expectedUserPrimitives = expectedUser.toPrimitives();
-		const expectedDomainEvent = UserRegisteredDomainEventMother.create(expectedUserPrimitives);
-
-		repository.shouldSave(expectedUser);
-		eventBus.shouldPublish([expectedDomainEvent]);
+		repository.shouldSave();
 
 		await userRegistrar.register(
 			expectedUserPrimitives.id,
@@ -23,5 +21,7 @@ describe("UserRegistrar should", () => {
 			expectedUserPrimitives.email,
 			expectedUserPrimitives.avatar
 		);
+
+		eventBus.assertLastPublishedEventIs(UserRegisteredDomainEvent);
 	});
 });

--- a/tests/contexts/cma/users/infrastructure/MockUserRepository.ts
+++ b/tests/contexts/cma/users/infrastructure/MockUserRepository.ts
@@ -5,50 +5,44 @@ import { UserRepository } from "../../../../../src/contexts/cma/users/domain/Use
 import { Criteria } from "../../../../../src/contexts/shared/domain/criteria/Criteria";
 
 export class MockUserRepository implements UserRepository {
-	private readonly mockSearchByEmail = jest.fn();
-	private readonly mockSearch = jest.fn();
-	private readonly mockMatching = jest.fn();
-	private readonly mockSave = jest.fn();
+	private mockSave = jest.fn();
+	private mockSearch = jest.fn();
+	private mockSearchByEmail = jest.fn();
+	private mockMatching = jest.fn();
 
 	async save(user: User): Promise<void> {
-		expect(this.mockSave).toHaveBeenCalledWith(user.toPrimitives());
-	}
-
-	async searchByEmail(email: UserEmail): Promise<User | null> {
-		expect(this.mockSearchByEmail).toHaveBeenCalledWith(email);
-
-		return this.mockSearchByEmail() as Promise<User | null>;
+		this.mockSave(user);
 	}
 
 	async search(id: UserId): Promise<User | null> {
-		expect(this.mockSearch).toHaveBeenCalledWith(id);
+		return this.mockSearch(id);
+	}
 
-		return this.mockSearch() as Promise<User | null>;
+	async searchByEmail(email: UserEmail): Promise<User | null> {
+		return this.mockSearchByEmail(email);
 	}
 
 	async matching(criteria: Criteria): Promise<User[]> {
-		expect(this.mockMatching).toHaveBeenCalledWith(criteria);
-
-		return this.mockMatching() as Promise<User[]>;
+		return this.mockMatching(criteria);
 	}
 
-	shouldSearchByEmail(user: User): void {
-		const { email } = user.toPrimitives();
-		this.mockSearchByEmail(email);
-		this.mockSearchByEmail.mockReturnValueOnce(user);
+	shouldSave(): void {
+		this.mockSave = jest.fn();
 	}
 
-	shouldSearch(user: User): void {
-		this.mockSearch(user.getId());
-		this.mockSearch.mockReturnValueOnce(user);
+	shouldSearch(user: User | null): void {
+		this.mockSearch.mockReturnValue(Promise.resolve(user));
 	}
 
-	shouldMatch(criteria: Criteria, users: User[]): void {
-		this.mockMatching(criteria);
-		this.mockMatching.mockReturnValueOnce(users);
+	shouldSearchByEmail(user: User | null): void {
+		this.mockSearchByEmail.mockReturnValue(Promise.resolve(user));
 	}
 
-	shouldSave(user: User): void {
-		this.mockSave(user.toPrimitives());
+	shouldMatch(users: User[]): void {
+		this.mockMatching.mockReturnValue(Promise.resolve(users));
+	}
+
+	assertSaveHaveBeenCalledWith(user: User): void {
+		expect(this.mockSave).toHaveBeenCalledWith(user);
 	}
 }

--- a/tests/contexts/shared/infrastructure/MockEventBus.ts
+++ b/tests/contexts/shared/infrastructure/MockEventBus.ts
@@ -2,23 +2,24 @@ import { DomainEvent } from "../../../../src/contexts/shared/domain/event/Domain
 import { EventBus } from "../../../../src/contexts/shared/domain/event/EventBus";
 
 export class MockEventBus implements EventBus {
-	private readonly mockPublish = jest.fn();
+	private mockPublish = jest.fn();
+	private publishedEvents: DomainEvent[] = [];
 
 	async publish(events: DomainEvent[]): Promise<void> {
-		expect(this.mockPublish).toHaveBeenCalledWith(
-			expect.arrayContaining(
-				events.map(event =>
-					expect.objectContaining({
-						...event,
-						eventId: expect.any(String),
-						occurredOn: expect.anything()
-					})
-				)
-			)
-		);
+		this.mockPublish(events);
+		this.publishedEvents.push(...events);
 	}
 
 	shouldPublish(events: DomainEvent[]): void {
-		this.mockPublish(events);
+		this.mockPublish = jest.fn();
+	}
+
+	getPublishedEvents(): DomainEvent[] {
+		return this.publishedEvents;
+	}
+
+	assertLastPublishedEventIs(expectedEvent: any): void {
+		const lastEvent = this.publishedEvents[this.publishedEvents.length - 1];
+		expect(lastEvent).toBeInstanceOf(expectedEvent);
 	}
 }

--- a/tests/contexts/shared/infrastructure/MockUuidGenerator.ts
+++ b/tests/contexts/shared/infrastructure/MockUuidGenerator.ts
@@ -1,16 +1,13 @@
 import { UuidGenerator } from "../../../../src/contexts/shared/domain/UuidGenerator";
 
 export class MockUuidGenerator implements UuidGenerator {
-	private readonly mockGenerate = jest.fn();
+	private mockGenerate = jest.fn();
 
 	async generate(): Promise<string> {
-		expect(this.mockGenerate).toHaveBeenCalledWith();
-
-		return this.mockGenerate() as Promise<string>;
+		return this.mockGenerate();
 	}
 
 	shouldGenerate(uuid: string): void {
-		this.mockGenerate();
-		this.mockGenerate.mockReturnValueOnce(uuid);
+		this.mockGenerate.mockReturnValue(Promise.resolve(uuid));
 	}
 }

--- a/tests/contexts/system/email/application/send-welcome-email/SendWelcomeEmailOnUserRegistered.test.ts
+++ b/tests/contexts/system/email/application/send-welcome-email/SendWelcomeEmailOnUserRegistered.test.ts
@@ -1,39 +1,26 @@
+import { faker } from "@faker-js/faker";
 import { SendWelcomeEmailOnUserRegistered } from "../../../../../../src/contexts/system/email/application/send-welcome-email/SendWelcomeEmailOnUserRegistered";
 import { WelcomeEmailSender } from "../../../../../../src/contexts/system/email/application/send-welcome-email/WelcomeEmailSender";
+import { WelcomeEmail } from "../../../../../../src/contexts/system/email/domain/WelcomeEmail";
 import { UserRegisteredDomainEventMother } from "../../../../cma/users/domain/event/UserRegisteredDomainEventMother";
 import { MockEventBus } from "../../../../shared/infrastructure/MockEventBus";
 import { MockUuidGenerator } from "../../../../shared/infrastructure/MockUuidGenerator";
-import { WelcomeEmailSentDomainEventMother } from "../../domain/event/WelcomeEmailSentDomainEventMother";
-import { WelcomeEmailMother } from "../../domain/WelcomeEmailMother";
 import { MockEmailSender } from "../../infrastructure/MockEmailSender";
 
 describe("SendWelcomeEmailOnUserRegistered should", () => {
-	const uuidGenerator = new MockUuidGenerator();
-	const emailSender = new MockEmailSender();
-	const eventBus = new MockEventBus();
-	const subscriber = new SendWelcomeEmailOnUserRegistered(
-		new WelcomeEmailSender(uuidGenerator, emailSender, eventBus)
-	);
-
 	it("send a welcome email when a user is registered", async () => {
+		const uuidGenerator = new MockUuidGenerator();
+		const emailSender = new MockEmailSender();
+		const eventBus = new MockEventBus();
+		const subscriber = new SendWelcomeEmailOnUserRegistered(
+			new WelcomeEmailSender(uuidGenerator, emailSender, eventBus)
+		);
 		const event = UserRegisteredDomainEventMother.create();
-
-		const email = WelcomeEmailMother.create({
-			userId: event.id,
-			userName: event.name,
-			from: "noreply@pnfi.uptag.net",
-			to: event.email,
-			subject: `Bienvenido al PNFi, ${event.name}`,
-			body: `Bienvenido a la cartelera del PNFi, ${event.name}! Completa tu perfil en https://cartelerapnfi.uptag.net/profile`
-		});
-
-		const expectedEmailPrimitives = email.toPrimitives();
-		const expectedDomainEvent =
-			WelcomeEmailSentDomainEventMother.create(expectedEmailPrimitives);
-		uuidGenerator.shouldGenerate(email.toPrimitives().id);
-		emailSender.shouldSend(email);
-		eventBus.shouldPublish([expectedDomainEvent]);
+		uuidGenerator.shouldGenerate(faker.string.uuid());
+		emailSender.shouldSend();
 
 		await subscriber.on(event);
+
+		emailSender.assertSendHaveBeenCalledWith(expect.any(WelcomeEmail));
 	});
 });

--- a/tests/contexts/system/email/infrastructure/MockEmailSender.ts
+++ b/tests/contexts/system/email/infrastructure/MockEmailSender.ts
@@ -2,13 +2,17 @@ import { Email } from "../../../../../src/contexts/system/email/domain/Email";
 import { EmailSender } from "../../../../../src/contexts/system/email/domain/EmailSender";
 
 export class MockEmailSender implements EmailSender {
-	private readonly mockSend = jest.fn();
+	private mockSend = jest.fn();
 
 	async send<T extends Email>(email: T): Promise<void> {
-		expect(this.mockSend).toHaveBeenCalledWith(email.toPrimitives());
+		this.mockSend(email);
 	}
 
-	shouldSend<T extends Email>(email: T): void {
-		this.mockSend(email.toPrimitives());
+	shouldSend(): void {
+		this.mockSend = jest.fn();
+	}
+
+	assertSendHaveBeenCalledWith(expectedEmail: any): void {
+		expect(this.mockSend).toHaveBeenCalledWith(expectedEmail);
 	}
 }


### PR DESCRIPTION
- Create missing application tests for cma context announcements
- Refactor mocks to be more flexible and reusable
- Fix existing tests that were failing due to snapshot mismatches